### PR TITLE
Upgrade GitHub Actions and Node version used in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,16 +1,20 @@
 name: CI
+
 on: push
+
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+
     strategy:
       matrix:
         node:
-          - '14'
-          - '16'
+          - 16
+          - 18
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: npm install


### PR DESCRIPTION
This PR is doing the following:

- use `ubuntu-latest` as base
- run tests using Node 16 and Node 18
- upgrade some GitHub Actions